### PR TITLE
Add support for a Global API key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,10 @@ const OpenCloud = {
         for (let key in config) {
             global.__OpenCloud[key] = config[key];
         }
+        if (config.Global) {
+            config.DataStoreService = config.Global
+            config.MessagingService = config.Global
+        }
     }
 }
 


### PR DESCRIPTION
Adds support for a global API key when configuring.
Whenever more services are added, just add `config.ServiceName = config.Global` to the if statement.
Solves #4 
(Very simple way to make this) 